### PR TITLE
mode option to combine my module annotation or project

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following options are added to TypeDoc when the plugin is installed:
 | Name & Format | Description | Default |
 | ------------- | ----------- | ------- |
 | **mergeModulesRenameDefaults** `<boolean>` | Defines if the plugin should rename default exports to their original name. | `true` |
+| **mergeModulesMergeMode** `<'project'|'module'>` | Defines if the plugin combine modules into project self or by module name. | `project` |
 
 ## Bugs
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -76,48 +76,51 @@ export class Plugin {
         const project = context.project;
         const modules = (project.children ?? []).filter((c) => c.kindOf(ReflectionKind.Module));
 
-        // conbine module DeclarationReflection by its module name
-        const combinedModules: Record<string, DeclarationReflection[]> = {};
-        modules.forEach((module) =>
-            combinedModules[module.name]
-                ? combinedModules[module.name].push(module)
-                : (combinedModules[module.name] = [module]),
-        );
+        switch (this.options.modeDefaults) {
+            case "project":
+                if (modules.length > 0) {
+                    project.children = [];
 
-        // reduce multiple DeclarationReflection into single declaration
-        for (const modName in combinedModules) {
-            const mods = combinedModules[modName];
-            const children = mods
-                .map((m) => m.children)
-                .reduce((acc, val) => (val ? (acc || []).concat(val) : acc), []);
-            // use first module as a principle module
-            mods[0].children = children;
-            // remove rest modules
-            for (let i = 1; i < mods.length; i++) {
-                mods[i].children = undefined;
-                project.removeReflection(mods[i]);
-            }
-        }
+                    for (const mod of modules) {
+                        const reflections = mod.children ?? [];
 
-        /*
-        if (modules.length > 0) {
-            project.children = [];
+                        for (const ref of reflections) {
+                            // Drop aliases
+                            if (!ref.kindOf(ReflectionKind.Reference)) {
+                                ref.parent = project;
+                                project.children.push(ref);
+                            }
+                        }
 
-            for (const mod of modules) {
-                const reflections = mod.children ?? [];
-
-                for (const ref of reflections) {
-                    // Drop aliases
-                    if (!ref.kindOf(ReflectionKind.Reference)) {
-                        ref.parent = project;
-                        project.children.push(ref);
+                        mod.children = undefined;
+                        project.removeReflection(mod);
                     }
                 }
+                break;
+            case "module":
+                // conbine module DeclarationReflection by its module name
+                const combinedModules: Record<string, DeclarationReflection[]> = {};
+                modules.forEach((module) =>
+                    combinedModules[module.name]
+                        ? combinedModules[module.name].push(module)
+                        : (combinedModules[module.name] = [module]),
+                );
 
-                mod.children = undefined;
-                project.removeReflection(mod);
-            }
+                // reduce multiple DeclarationReflection into single declaration
+                for (const modName in combinedModules) {
+                    const mods = combinedModules[modName];
+                    const children = mods
+                        .map((m) => m.children)
+                        .reduce((acc, val) => (val ? (acc || []).concat(val) : acc), []);
+                    // use first module as a principle module
+                    mods[0].children = children;
+                    // remove rest modules
+                    for (let i = 1; i < mods.length; i++) {
+                        mods[i].children = undefined;
+                        project.removeReflection(mods[i]);
+                    }
+                }
+                break;
         }
-        */
     }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -98,28 +98,30 @@ export class Plugin {
                 }
                 break;
             case "module":
-                // conbine module DeclarationReflection by its module name
-                const combinedModules: Record<string, DeclarationReflection[]> = {};
-                modules.forEach((module) =>
-                    combinedModules[module.name]
-                        ? combinedModules[module.name].push(module)
-                        : (combinedModules[module.name] = [module]),
-                );
+                {
+                    // conbine module DeclarationReflection by its module name
+                    const combinedModules: Record<string, DeclarationReflection[]> = {};
+                    modules.forEach((module) =>
+                        (Array.isArray(combinedModules[module.name])
+                            ? combinedModules[module.name].push(module)
+                            : (combinedModules[module.name] = [module])),
+                    );
 
-                // reduce multiple DeclarationReflection into single declaration
-                for (const modName in combinedModules) {
-                    const mods = combinedModules[modName];
-                    const children = mods
-                        .map((m) => m.children)
-                        .filter((m): m is DeclarationReflection[] => m !== undefined)
-                        .reduce((acc, val) => acc.concat(val), []);
-                    // use first module as a principle module
-                    children.forEach((child) => (child.parent = mods[0]));
-                    mods[0].children = children;
-                    // remove rest modules
-                    for (let i = 1; i < mods.length; i++) {
-                        mods[i].children = undefined;
-                        project.removeReflection(mods[i]);
+                    // reduce multiple DeclarationReflection into single declaration
+                    for (const modName in combinedModules) {
+                        const mods = combinedModules[modName];
+                        const children = mods
+                            .map((m) => m.children)
+                            .filter((m): m is DeclarationReflection[] => m !== undefined)
+                            .reduce((acc, val) => acc.concat(val), []);
+                        // use first module as a principle module
+                        children.forEach((child) => (child.parent = mods[0]));
+                        mods[0].children = children;
+                        // remove rest modules
+                        for (let i = 1; i < mods.length; i++) {
+                            mods[i].children = undefined;
+                            project.removeReflection(mods[i]);
+                        }
                     }
                 }
                 break;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -101,10 +101,11 @@ export class Plugin {
                 {
                     // conbine module DeclarationReflection by its module name
                     const combinedModules: Record<string, DeclarationReflection[]> = {};
+                    // eslint-disable-next-line no-confusing-arrow
                     modules.forEach((module) =>
-                        (Array.isArray(combinedModules[module.name])
+                        Array.isArray(combinedModules[module.name])
                             ? combinedModules[module.name].push(module)
-                            : (combinedModules[module.name] = [module])),
+                            : (combinedModules[module.name] = [module]),
                     );
 
                     // reduce multiple DeclarationReflection into single declaration

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -111,8 +111,10 @@ export class Plugin {
                     const mods = combinedModules[modName];
                     const children = mods
                         .map((m) => m.children)
-                        .reduce((acc, val) => (val ? (acc || []).concat(val) : acc), []);
+                        .filter((m): m is DeclarationReflection[] => m !== undefined)
+                        .reduce((acc, val) => acc.concat(val), []);
                     // use first module as a principle module
+                    children.forEach((child) => (child.parent = mods[0]));
                     mods[0].children = children;
                     // remove rest modules
                     for (let i = 1; i < mods.length; i++) {

--- a/src/plugin_options.ts
+++ b/src/plugin_options.ts
@@ -1,5 +1,7 @@
 import { Application, ParameterType } from "typedoc";
 
+type Mode = "project" | "module";
+
 /**
  * Extend typedoc's options with the plugin's option using declaration merging.
  */
@@ -7,6 +9,7 @@ declare module "typedoc" {
     // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- This is not a separate type.
     export interface TypeDocOptionMap {
         mergeModulesRenameDefaults?: boolean;
+        mergeModulesMergeMode?: Mode;
     }
 }
 
@@ -17,12 +20,23 @@ export class PluginOptions {
     /** Defines if the plugin should rename default exports to their original name. */
     private _renameDefaults = true;
 
+    /** Defines if the plugin combine modules into project self or by module name. */
+    private _modeDefaults: Mode = "project";
+
     /**
      * Returns if the plugin should rename default exports to their original name.
      * @returns True, if the plugin should rename default exports to their original name, otherwise false.
      */
     public get renameDefaults(): boolean {
         return this._renameDefaults;
+    }
+
+    /**
+     * Returns if the plugin combine modules into project self or by module name.
+     * @returns 'project', if the plugin combine modules into project self or by module name, otherwise 'module'.
+     */
+    public get modeDefaults(): Mode {
+        return this._modeDefaults;
     }
 
     /**
@@ -37,6 +51,15 @@ export class PluginOptions {
             help: "If true default exports are renamed to their original name as their module is merged.",
             defaultValue: true,
         });
+
+        typedoc.options.addDeclaration({
+            type: ParameterType.String,
+            name: "mergeModulesMergeMode",
+            help:
+                // eslint-disable-next-line max-len
+                "Move all modules into project itself with 'project' ( default ). If 'module' set, modules combined by its name",
+            defaultValue: "project",
+        });
     }
 
     /**
@@ -45,5 +68,6 @@ export class PluginOptions {
      */
     public readValuesFromApplication(typedoc: Readonly<Application>): void {
         this._renameDefaults = typedoc.options.getValue("mergeModulesRenameDefaults") ?? this._renameDefaults;
+        this._modeDefaults = typedoc.options.getValue("mergeModulesMergeMode") ?? this._modeDefaults;
     }
 }


### PR DESCRIPTION
add `mergeModulesMergeMode` option to set mode `module` to combine modules by `@module` annotation.
it means you can set same `@module` name and all reflections will be combined by its declaration rather than project root

```
src/
├── index.ts         @module main
├── module1
│   └── index.ts     @module submodule
├── module2
│   └── index.ts     @module submodule
├── module3.ts       @module main
└── module4 
    └── module4-1
        └── index.ts @module main
```

this goes ⬇️ 

<img width="396" alt="Screen Shot 2021-05-31 at 20 03 58" src="https://user-images.githubusercontent.com/72931444/120183970-618e8d00-c24b-11eb-9f86-6ed81f230992.png">

---

I made this pull request because I need this feature and feel `typedoc-plugin-merge-modules`  matches to this idea.
However I will understand this may be out of this plugins concept. I that case I will make this as a other plugin.