### PR TITLE
Allow to use TypeDoc 0.24.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typedoc-plugin-merge-modules",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "description": "Plugin for TypeDoc that merges the content of modules.",
     "author": {
         "name": "Krisztián Balla",
@@ -24,7 +24,7 @@
         "typescript": "4.7.4"
     },
     "peerDependencies": {
-        "typedoc": "0.23.x"
+        "typedoc": "0.23.x || 0.24.x"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Current peer dependency version disallows to use the plugin with [TypeDoc release 0.24+](https://github.com/TypeStrong/typedoc/releases) with plain `npm i`:

```
>  npm i

npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: typedoc-plugin-merge-modules@4.0.1
npm ERR! Found: typedoc@0.24.4
npm ERR! node_modules/typedoc
npm ERR!   dev typedoc@"0.24.4" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer typedoc@"0.23.x" from typedoc-plugin-merge-modules@4.0.1
npm ERR! node_modules/typedoc-plugin-merge-modules
npm ERR!   dev typedoc-plugin-merge-modules@"^4.0.1" from the root project
```

It's still possible to use the current plugin version with `npm i --force` or `npm i --legacy-peer-deps`, but it's not that convenient.

Current plugin version still works as expected **_(on my project)_** with TypeDoc 0.24.4, so this PR is about extending allowed versions of TypeDoc.