### PR TITLE
Allow to use TypeDoc 0.25.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "typedoc-plugin-merge-modules",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "typedoc-plugin-merge-modules",
-            "version": "5.0.1",
+            "version": "5.0.2",
             "license": "ISC",
             "devDependencies": {
                 "@types/mocha": "10.0.1",
@@ -20,11 +20,11 @@
                 "eslint-plugin-unicorn": "47.0.0",
                 "prettier": "2.8.8",
                 "rimraf": "5.0.1",
-                "typedoc": "0.24.7",
+                "typedoc": "0.25.0",
                 "typescript": "5.0.4"
             },
             "peerDependencies": {
-                "typedoc": "0.24.x"
+                "typedoc": "0.24.x || 0.25.x"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -4032,24 +4032,24 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.24.7",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
-            "integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.0.tgz",
+            "integrity": "sha512-FvCYWhO1n5jACE0C32qg6b3dSfQ8f2VzExnnRboowHtqUD6ARzM2r8YJeZFYXhcm2hI4C2oCRDgNPk/yaQUN9g==",
             "dev": true,
             "dependencies": {
                 "lunr": "^2.3.9",
                 "marked": "^4.3.0",
-                "minimatch": "^9.0.0",
+                "minimatch": "^9.0.3",
                 "shiki": "^0.14.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
             },
             "engines": {
-                "node": ">= 14.14"
+                "node": ">= 16"
             },
             "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x"
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
@@ -4062,9 +4062,9 @@
             }
         },
         "node_modules/typedoc/node_modules/minimatch": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
-            "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -7176,14 +7176,14 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.24.7",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
-            "integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.0.tgz",
+            "integrity": "sha512-FvCYWhO1n5jACE0C32qg6b3dSfQ8f2VzExnnRboowHtqUD6ARzM2r8YJeZFYXhcm2hI4C2oCRDgNPk/yaQUN9g==",
             "dev": true,
             "requires": {
                 "lunr": "^2.3.9",
                 "marked": "^4.3.0",
-                "minimatch": "^9.0.0",
+                "minimatch": "^9.0.3",
                 "shiki": "^0.14.1"
             },
             "dependencies": {
@@ -7197,9 +7197,9 @@
                     }
                 },
                 "minimatch": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
-                    "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+                    "version": "9.0.3",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+                    "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "typescript": "5.0.4"
     },
     "peerDependencies": {
-        "typedoc": "^0.24.x"
+        "typedoc": "^0.24.x || ^0.25.x"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typedoc-plugin-merge-modules",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "Plugin for TypeDoc that merges the content of modules.",
     "author": {
         "name": "Krisztián Balla",
@@ -23,11 +23,11 @@
         "eslint-plugin-unicorn": "47.0.0",
         "prettier": "2.8.8",
         "rimraf": "5.0.1",
-        "typedoc": "0.24.7",
+        "typedoc": "0.25.0",
         "typescript": "5.0.4"
     },
     "peerDependencies": {
-        "typedoc": "0.24.x"
+        "typedoc": "^0.24.x"
     },
     "repository": {
         "type": "git",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -88,7 +88,6 @@ export class Plugin {
                 ReflectionKind.ClassOrInterface |
                     ReflectionKind.Enum |
                     ReflectionKind.Function |
-                    ReflectionKind.ObjectLiteral |
                     ReflectionKind.TypeAlias |
                     ReflectionKind.TypeLiteral |
                     ReflectionKind.Variable,


### PR DESCRIPTION
The current peer dependency version prevents upgrading to the latest version of TypeDoc 0.25.0

```
>  npm i

npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: Workspace@0.0.1
npm ERR! Found: typedoc@0.25.0
npm ERR! node_modules/typedoc
npm ERR!   dev typedoc@"^0.25.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer typedoc@"0.24.x" from typedoc-plugin-merge-modules@5.0.1
npm ERR! node_modules/typedoc-plugin-merge-modules
npm ERR!   dev typedoc-plugin-merge-modules@"5.0.1" from the root project```
```

While it's still possible to use the current plugin version with `npm i --force` or `npm i --legacy-peer-deps`, it's not that convenient - this PR extends the allowed versions of TypeDoc.