### PR TITLE
project_merger with module_bundle

### DIFF
--- a/src/merger/module_bundle.ts
+++ b/src/merger/module_bundle.ts
@@ -45,10 +45,14 @@ export class ModuleBundle {
      * Merges the modules of the bundle into one module.
      * @param categorizationHasAlreadyHappened Defines if TypeDoc has already categorized the
      *                                         reflections in the modules of the bundle.
+     * @param targetOverride A module to target, taking precendence over the bundle's search.
      */
-    public merge(categorizationHasAlreadyHappened: boolean): void {
+    public merge(
+        categorizationHasAlreadyHappened: boolean,
+        targetOverride?: DeclarationReflection | ProjectReflection,
+    ): void {
         // get target module
-        const targetModule = this.getTargetModule();
+        const targetModule = targetOverride ?? this.getTargetModule();
         removeTagFromCommentsOf(targetModule, targetModuleCommentTag);
 
         this.mergeChildrenAndDocumentsIntoTargetModule(targetModule);
@@ -101,7 +105,7 @@ export class ModuleBundle {
         return this.modules[0];
     }
 
-    private mergeChildrenAndDocumentsIntoTargetModule(targetModule: DeclarationReflection): void {
+    private mergeChildrenAndDocumentsIntoTargetModule(targetModule: DeclarationReflection | ProjectReflection): void {
         for (const mod of this.modules) {
             // Here we create a copy because the next loop modifies the collection
             const reflections = [...(mod.childrenIncludingDocuments ?? [])];
@@ -125,7 +129,7 @@ export class ModuleBundle {
     // eslint-disable-next-line class-methods-use-this
     private moveDeclarationReflectionToTargetModule(
         ref: DeclarationReflection,
-        targetModule: DeclarationReflection,
+        targetModule: DeclarationReflection | ProjectReflection,
     ): void {
         removeDeclarationReflectionFromModule(ref);
         addDeclarationReflectionToTarget(ref, targetModule);
@@ -138,7 +142,10 @@ export class ModuleBundle {
      * @throws {Error} If the given reflection is not within a module.
      */
     // eslint-disable-next-line class-methods-use-this
-    private moveDocumentReflectionToTargetModule(ref: DocumentReflection, targetModule: DeclarationReflection): void {
+    private moveDocumentReflectionToTargetModule(
+        ref: DocumentReflection,
+        targetModule: DeclarationReflection | ProjectReflection,
+    ): void {
         removeDocumentReflectionFromModule(ref);
         addDocumentReflectionToTarget(ref, targetModule);
     }
@@ -147,7 +154,7 @@ export class ModuleBundle {
      * Merges the children from all modules' categories into the corresponding category of the given target module.
      * @param targetModule The target module into whoes categories the children should be merged.
      */
-    private mergeCategoriesIntoTargetModule(targetModule: DeclarationReflection): void {
+    private mergeCategoriesIntoTargetModule(targetModule: DeclarationReflection | ProjectReflection): void {
         // merge categories
         this.modules.forEach((module) => {
             if (module !== targetModule) {
@@ -183,7 +190,7 @@ export class ModuleBundle {
      * Copies the category description comment tags into the the given target module.
      * @param targetModule The target module into which the category descriptions are merged.
      */
-    private copyCategoryDescriptionTagsIntoTargetModule(targetModule: DeclarationReflection): void {
+    private copyCategoryDescriptionTagsIntoTargetModule(targetModule: DeclarationReflection | ProjectReflection): void {
         this.modules.forEach((module) => {
             if (module !== targetModule) {
                 const categoryDescriptionsOfModule =
@@ -216,7 +223,7 @@ export class ModuleBundle {
      * Merges the children from all modules' groups into the corresponding group of the given target module.
      * @param targetModule The target module into whoes groups the children should be merged.
      */
-    private mergeGroupsIntoTargetModule(targetModule: DeclarationReflection): void {
+    private mergeGroupsIntoTargetModule(targetModule: DeclarationReflection | ProjectReflection): void {
         // merge groups
         this.modules.forEach((module) => {
             if (module !== targetModule) {
@@ -253,7 +260,7 @@ export class ModuleBundle {
      * Copies the group description comment tags into the the given target module.
      * @param targetModule The target module into which the group descriptions are merged.
      */
-    private copyGroupDescriptionTagsIntoTargetModule(targetModule: DeclarationReflection): void {
+    private copyGroupDescriptionTagsIntoTargetModule(targetModule: DeclarationReflection | ProjectReflection): void {
         this.modules.forEach((module) => {
             if (module !== targetModule) {
                 const groupDescriptionsOfModule =

--- a/src/merger/project_merger.ts
+++ b/src/merger/project_merger.ts
@@ -1,11 +1,8 @@
-import { DeclarationReflection, DocumentReflection, ProjectReflection, ReflectionKind } from "typedoc";
-import {
-    addDeclarationReflectionToTarget,
-    addDocumentReflectionToTarget,
-    getModulesFrom,
-    removeDeclarationReflectionFromModule,
-    removeDocumentReflectionFromModule,
-} from "../utils";
+import { ProjectReflection } from "typedoc";
+import { Plugin } from "../plugin";
+import { getModulesFrom } from "../utils";
+import { ModuleBundle } from "./module_bundle";
+
 
 /**
  * Merger that moves the content of all modules into the project root.
@@ -14,12 +11,17 @@ export class ProjectMerger {
     /** The project whose modules are merged. */
     private readonly project: ProjectReflection;
 
+    /** The plugin which is using this merger. */
+    private readonly plugin: Plugin;
+
     /**
      * Creates a new merger instance.
      * @param project The project whose modules are merged.
-     */
-    public constructor(project: ProjectReflection) {
+     * @param plugin The plugin which is using this merger.
+    */
+    public constructor(project: ProjectReflection, plugin: Plugin) {
         this.project = project;
+        this.plugin = plugin;
     }
 
     /**
@@ -29,56 +31,8 @@ export class ProjectMerger {
         // In monorepo project each project is also a module => Recursively collect all modules
         const allModules = getModulesFrom(this.project);
 
-        if (allModules.length > 0) {
-            this.removeModulesFromProject();
-
-            for (const module of allModules) {
-                // Here we create a copy because the next loop modifies the collection
-                const reflections = [...(module.childrenIncludingDocuments ?? [])];
-
-                for (const ref of reflections) {
-                    // Drop aliases (= ReflectionKind.Reference) and modules
-                    if (
-                        ref instanceof DeclarationReflection &&
-                        !ref.kindOf([ReflectionKind.Reference, ReflectionKind.Module])
-                    ) {
-                        this.moveDeclarationReflectionToProject(ref);
-                    } else if (ref instanceof DocumentReflection) {
-                        this.moveDocumentReflectionFromToProject(ref);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Removes all modules from the project reflection. Doesn't touch the project documents.
-     */
-    private removeModulesFromProject(): void {
-        this.project.children = [];
-        this.project.children.forEach((child) => this.project.removeReflection(child));
-
-        // keep project documents that are included with the TypeDoc config parameter "projectDocuments"
-        this.project.childrenIncludingDocuments =
-            this.project.childrenIncludingDocuments?.filter((item) => item instanceof DocumentReflection) ?? [];
-    }
-
-    /**
-     * Moves a declaration reflection to the project root.
-     * @param ref The declaration reflection that should be moved.
-     */
-    private moveDeclarationReflectionToProject(ref: DeclarationReflection): void {
-        removeDeclarationReflectionFromModule(ref);
-        addDeclarationReflectionToTarget(ref, this.project);
-    }
-
-    /**
-     * Moves a document reflection to the project root.
-     * @param ref The document reflection that should be moved.
-     * @throws {Error} If the given reflection is not within a module.
-     */
-    private moveDocumentReflectionFromToProject(ref: DocumentReflection): void {
-        removeDocumentReflectionFromModule(ref);
-        addDocumentReflectionToTarget(ref, this.project);
+        const bundle = new ModuleBundle(this.project);
+        allModules.forEach((module) => bundle.add(module));
+        bundle.merge(this.plugin.runsAfterCategorization, this.project);
     }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -144,7 +144,7 @@ export class Plugin {
      */
     private createMerger(project: ProjectReflection): ProjectMerger | ModuleMerger | undefined {
         if (this._options.mode === "project") {
-            return new ProjectMerger(project);
+            return new ProjectMerger(project, this);
         } else if (this._options.mode === "module") {
             return new ModuleMerger(project, this);
         } else if (this._options.mode === "module-category") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,10 @@ export function tryGetOriginalReflectionName(
  * @param reflection The reflection from which the tag should be removed.
  * @param tagToRemove Name of the tag to be removed.
  */
-export function removeTagFromCommentsOf(reflection: DeclarationReflection, tagToRemove: string): void {
+export function removeTagFromCommentsOf(
+    reflection: DeclarationReflection | ProjectReflection,
+    tagToRemove: string,
+): void {
     const tagIndex = reflection.comment?.blockTags.findIndex((ct) => ct.tag === tagToRemove) ?? -1;
 
     if (tagIndex !== -1) {


### PR DESCRIPTION
#18 still occurs when `mergeModulesMergeMode: "project"`. Those bug fixes were applied only to `ModuleBundle`, and not to similar code in `ProjectMerger`. Rather than patch the changes over, this commit simplifies `ProjectMerger` by directly using `ModuleBundle`. This includes adding an addition target module parameter to `ModuleBundle.merge`, and widening the typings of the `targetModule` parameter of `ModuleBundle`'s other functions.