### PR TITLE
crossplatform testing support

### DIFF
--- a/test/prepare_test.js
+++ b/test/prepare_test.js
@@ -1,28 +1,40 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require("fs");
+const path = require("path");
 
 console.log("=================================== SETTING UP THE TESTS ===========================================");
 
-if (!fs.existsSync("..\\dist")) {
+if (!fs.existsSync(path.join("..", "dist"))) {
     console.error("ERROR: Cannot find 'dist' folder. Did you forget to build the plugin with 'npm run build'?");
     process.exit(1);
 }
 
 console.log("Copying current build of plugin to node_modules for testing...");
+const modulesDir = path.join("..", "node_modules", "typedoc-plugin-merge-modules");
 
-fs.rm("..\\node_modules\\typedoc-plugin-merge-modules", { recursive: true, force: true }, (rmErr) => {
+fs.rm(modulesDir, { recursive: true, force: true }, (rmErr) => {
     if (rmErr) {
         throw rmErr;
-    } else {
-        fs.mkdir("..\\node_modules\\typedoc-plugin-merge-modules\\dist", { recursive: true }, (mkDirErr) => {
+    }
+    fs.mkdir(
+        path.join(modulesDir, "dist"),
+        { recursive: true },
+        (mkDirErr) => {
             if (mkDirErr) {
                 throw mkDirErr;
             } else {
-                fs.copyFileSync("..\\package.json", "..\\node_modules\\typedoc-plugin-merge-modules\\package.json");
-                fs.cpSync("..\\dist", "..\\node_modules\\typedoc-plugin-merge-modules\\dist", { recursive: true });
+                fs.copyFileSync(
+                    path.join("..", "package.json"),
+                    path.join(modulesDir, "package.json"),
+                );
+                fs.cpSync(
+                    path.join("..", "dist"),
+                    path.join(modulesDir, "dist"),
+                    { recursive: true },
+                );
             }
         });
-    }
+
 });
 
 console.log("DONE\n");

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ const execOptions = { stdio: "inherit" };
 
 console.log("===================================== TEST MERGE OFF ===============================================");
 execSync("cd merge-off && npx typedoc", execOptions);
-execSync("call npx cypress run --quiet --spec 'merge-off/test.cy.ts'", execOptions);
+execSync("npx cypress run --quiet --spec 'merge-off/test.cy.ts'", execOptions);
 
 console.log("=================================== TEST MERGE PROJECT =============================================");
 execSync("cd merge-project && npx typedoc", execOptions);


### PR DESCRIPTION
Allows testing on linux systems by using `path.join` in [test/prepare_test.js](https://github.com/krisztianb/typedoc-plugin-merge-modules/compare/master...cbunt:typedoc-plugin-merge-modules:crossplatform-testing-support#diff-7f3dbb71efd9289e617901c14e18ac9f178539a5851cc88b4fa50308829ae88d) and removing a redundant `call` in `execSync("call npx ...")` in [test/test.js](https://github.com/krisztianb/typedoc-plugin-merge-modules/compare/master...cbunt:typedoc-plugin-merge-modules:crossplatform-testing-support#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2f).