### PR TITLE
Switch from CommonJS to ESM, required for support for TypeDoc 0.27.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "typedoc-plugin-merge-modules",
-    "version": "6.0.1",
+    "version": "6.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "typedoc-plugin-merge-modules",
-            "version": "6.0.1",
+            "version": "6.0.3",
             "license": "ISC",
             "devDependencies": {
                 "@types/node": "20.14.9",
@@ -19,11 +19,11 @@
                 "eslint-plugin-unicorn": "54.0.0",
                 "prettier": "3.3.3",
                 "rimraf": "6.0.1",
-                "typedoc": "0.26.7",
+                "typedoc": "0.27.0",
                 "typescript": "5.5.4"
             },
             "peerDependencies": {
-                "typedoc": "0.26.x"
+                "typedoc": "0.27.x"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -272,6 +272,18 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@gerrit0/mini-shiki": {
+            "version": "1.23.2",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.23.2.tgz",
+            "integrity": "sha512-6e/41ZAilc2iE4n0bxxMSvzrt1dy2MSa9lSdd2M5lcTDlrzcau+FucIEDrG+xF1dPou/a093tm1t4HPTSI4g1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/engine-oniguruma": "^1.23.1",
+                "@shikijs/types": "^1.23.1",
+                "@shikijs/vscode-textmate": "^9.3.0"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -460,56 +472,34 @@
                 "url": "https://opencollective.com/unts"
             }
         },
-        "node_modules/@shikijs/core": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.18.0.tgz",
-            "integrity": "sha512-VK4BNVCd2leY62Nm2JjyxtRLkyrZT/tv104O81eyaCjHq4Adceq2uJVFJJAIof6lT1mBwZrEo2qT/T+grv3MQQ==",
-            "dev": true,
-            "dependencies": {
-                "@shikijs/engine-javascript": "1.18.0",
-                "@shikijs/engine-oniguruma": "1.18.0",
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
-                "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.3"
-            }
-        },
-        "node_modules/@shikijs/engine-javascript": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.18.0.tgz",
-            "integrity": "sha512-qoP/aO/ATNwYAUw1YMdaip/YVEstMZEgrwhePm83Ll9OeQPuxDZd48szZR8oSQNQBT8m8UlWxZv8EA3lFuyI5A==",
-            "dev": true,
-            "dependencies": {
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
-                "oniguruma-to-js": "0.4.3"
-            }
-        },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.18.0.tgz",
-            "integrity": "sha512-B9u0ZKI/cud+TcmF8Chyh+R4V5qQVvyDOqXC2l2a4x73PBSBc6sZ0JRAX3eqyJswqir6ktwApUUGBYePdKnMJg==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz",
+            "integrity": "sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2"
+                "@shikijs/types": "1.23.1",
+                "@shikijs/vscode-textmate": "^9.3.0"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.18.0.tgz",
-            "integrity": "sha512-O9N36UEaGGrxv1yUrN2nye7gDLG5Uq0/c1LyfmxsvzNPqlHzWo9DI0A4+fhW2y3bGKuQu/fwS7EPdKJJCowcVA==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.23.1.tgz",
+            "integrity": "sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@shikijs/vscode-textmate": "^9.2.2",
+                "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4"
             }
         },
         "node_modules/@shikijs/vscode-textmate": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz",
-            "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==",
-            "dev": true
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
+            "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/eslint": {
             "version": "8.56.10",
@@ -532,6 +522,7 @@
             "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
             "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
             }
@@ -541,15 +532,6 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
-        },
-        "node_modules/@types/mdast": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-            "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "*"
-            }
         },
         "node_modules/@types/node": {
             "version": "20.14.9",
@@ -582,7 +564,8 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.0",
@@ -1235,16 +1218,6 @@
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
             "dev": true
         },
-        "node_modules/ccount": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1259,26 +1232,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/character-entities-html4": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-            "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/character-entities-legacy": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/check-more-types": {
@@ -1412,16 +1365,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/comma-separated-tokens": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/commander": {
@@ -1627,28 +1570,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/dequal": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/devlop": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-            "dev": true,
-            "dependencies": {
-                "dequal": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/dir-glob": {
@@ -2735,57 +2656,11 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/hast-util-to-html": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
-            "integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
-            "dev": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/unist": "^3.0.0",
-                "ccount": "^2.0.0",
-                "comma-separated-tokens": "^2.0.0",
-                "hast-util-whitespace": "^3.0.0",
-                "html-void-elements": "^3.0.0",
-                "mdast-util-to-hast": "^13.0.0",
-                "property-information": "^6.0.0",
-                "space-separated-tokens": "^2.0.0",
-                "stringify-entities": "^4.0.0",
-                "zwitch": "^2.0.4"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/hast-util-whitespace": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-            "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-            "dev": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
-        },
-        "node_modules/html-void-elements": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-            "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
         },
         "node_modules/http-signature": {
             "version": "1.4.0",
@@ -3360,27 +3235,6 @@
                 "markdown-it": "bin/markdown-it.mjs"
             }
         },
-        "node_modules/mdast-util-to-hast": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-            "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
-            "dev": true,
-            "dependencies": {
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "@ungap/structured-clone": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-util-sanitize-uri": "^2.0.0",
-                "trim-lines": "^3.0.0",
-                "unist-util-position": "^5.0.0",
-                "unist-util-visit": "^5.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/mdurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -3401,95 +3255,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "dependencies": {
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-encode": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ]
-        },
-        "node_modules/micromark-util-sanitize-uri": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "dependencies": {
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-encode": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ]
-        },
-        "node_modules/micromark-util-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
-            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ]
         },
         "node_modules/micromatch": {
             "version": "4.0.7",
@@ -3658,18 +3423,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/oniguruma-to-js": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
-            "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
-            "dev": true,
-            "dependencies": {
-                "regex": "^4.3.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/optionator": {
@@ -3946,16 +3699,6 @@
                 "node": ">= 0.6.0"
             }
         },
-        "node_modules/property-information": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
-            "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/proxy-from-env": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -4086,12 +3829,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/regex": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.2.tgz",
-            "integrity": "sha512-kK/AA3A9K6q2js89+VMymcboLOlF5lZRCYJv3gzszXFHBr6kO6qLGzbm+UIugBEV8SMMKCTR59txoY6ctRHYVw==",
-            "dev": true
         },
         "node_modules/regexp-tree": {
             "version": "0.1.27",
@@ -4326,20 +4063,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/shiki": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.18.0.tgz",
-            "integrity": "sha512-8jo7tOXr96h9PBQmOHVrltnETn1honZZY76YA79MHheGQg55jBvbm9dtU+MI5pjC5NJCFuA6rvVTLVeSW5cE4A==",
-            "dev": true,
-            "dependencies": {
-                "@shikijs/core": "1.18.0",
-                "@shikijs/engine-javascript": "1.18.0",
-                "@shikijs/engine-oniguruma": "1.18.0",
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
-                "@types/hast": "^3.0.4"
-            }
-        },
         "node_modules/side-channel": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -4397,16 +4120,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/space-separated-tokens": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/spdx-correct": {
@@ -4493,20 +4206,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/stringify-entities": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-            "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-            "dev": true,
-            "dependencies": {
-                "character-entities-html4": "^2.0.0",
-                "character-entities-legacy": "^3.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/strip-ansi": {
@@ -4670,16 +4369,6 @@
                 "node": ">= 4.0.0"
             }
         },
-        "node_modules/trim-lines": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-            "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/ts-api-utils": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -4741,16 +4430,17 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.26.7",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.7.tgz",
-            "integrity": "sha512-gUeI/Wk99vjXXMi8kanwzyhmeFEGv1LTdTQsiyIsmSYsBebvFxhbcyAx7Zjo4cMbpLGxM4Uz3jVIjksu/I2v6Q==",
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.0.tgz",
+            "integrity": "sha512-7AkTJhFdhsihthaBFHNpj5iFdLyR7FpQqXM+IABJmE1/qTjWypirCLrheToUP3fjpWHN1Drn3K7PWH1t37KvNQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
+                "@gerrit0/mini-shiki": "^1.23.2",
                 "lunr": "^2.3.9",
                 "markdown-it": "^14.1.0",
                 "minimatch": "^9.0.5",
-                "shiki": "^1.16.2",
-                "yaml": "^2.5.1"
+                "yaml": "^2.6.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
@@ -4759,7 +4449,7 @@
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x"
+                "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
@@ -4810,74 +4500,6 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
-        },
-        "node_modules/unist-util-is": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-            "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-position": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-            "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-stringify-position": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-visit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-            "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "unist-util-is": "^6.0.0",
-                "unist-util-visit-parents": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-visit-parents": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-            "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "unist-util-is": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
         },
         "node_modules/universalify": {
             "version": "2.0.0",
@@ -4979,34 +4601,6 @@
                 "extsprintf": "^1.2.0"
             }
         },
-        "node_modules/vfile": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-            "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "vfile-message": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/vfile-message": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-            "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
-            "dev": true,
-            "dependencies": {
-                "@types/unist": "^3.0.0",
-                "unist-util-stringify-position": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5064,10 +4658,11 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+            "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -5095,16 +4690,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/zwitch": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         }
     },
@@ -5305,6 +4890,17 @@
             "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
             "dev": true
         },
+        "@gerrit0/mini-shiki": {
+            "version": "1.23.2",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.23.2.tgz",
+            "integrity": "sha512-6e/41ZAilc2iE4n0bxxMSvzrt1dy2MSa9lSdd2M5lcTDlrzcau+FucIEDrG+xF1dPou/a093tm1t4HPTSI4g1w==",
+            "dev": true,
+            "requires": {
+                "@shikijs/engine-oniguruma": "^1.23.1",
+                "@shikijs/types": "^1.23.1",
+                "@shikijs/vscode-textmate": "^9.3.0"
+            }
+        },
         "@humanwhocodes/config-array": {
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -5432,55 +5028,30 @@
             "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
             "dev": true
         },
-        "@shikijs/core": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.18.0.tgz",
-            "integrity": "sha512-VK4BNVCd2leY62Nm2JjyxtRLkyrZT/tv104O81eyaCjHq4Adceq2uJVFJJAIof6lT1mBwZrEo2qT/T+grv3MQQ==",
-            "dev": true,
-            "requires": {
-                "@shikijs/engine-javascript": "1.18.0",
-                "@shikijs/engine-oniguruma": "1.18.0",
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
-                "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.3"
-            }
-        },
-        "@shikijs/engine-javascript": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.18.0.tgz",
-            "integrity": "sha512-qoP/aO/ATNwYAUw1YMdaip/YVEstMZEgrwhePm83Ll9OeQPuxDZd48szZR8oSQNQBT8m8UlWxZv8EA3lFuyI5A==",
-            "dev": true,
-            "requires": {
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
-                "oniguruma-to-js": "0.4.3"
-            }
-        },
         "@shikijs/engine-oniguruma": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.18.0.tgz",
-            "integrity": "sha512-B9u0ZKI/cud+TcmF8Chyh+R4V5qQVvyDOqXC2l2a4x73PBSBc6sZ0JRAX3eqyJswqir6ktwApUUGBYePdKnMJg==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz",
+            "integrity": "sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==",
             "dev": true,
             "requires": {
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2"
+                "@shikijs/types": "1.23.1",
+                "@shikijs/vscode-textmate": "^9.3.0"
             }
         },
         "@shikijs/types": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.18.0.tgz",
-            "integrity": "sha512-O9N36UEaGGrxv1yUrN2nye7gDLG5Uq0/c1LyfmxsvzNPqlHzWo9DI0A4+fhW2y3bGKuQu/fwS7EPdKJJCowcVA==",
+            "version": "1.23.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.23.1.tgz",
+            "integrity": "sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==",
             "dev": true,
             "requires": {
-                "@shikijs/vscode-textmate": "^9.2.2",
+                "@shikijs/vscode-textmate": "^9.3.0",
                 "@types/hast": "^3.0.4"
             }
         },
         "@shikijs/vscode-textmate": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz",
-            "integrity": "sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
+            "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
             "dev": true
         },
         "@types/eslint": {
@@ -5513,15 +5084,6 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
-        },
-        "@types/mdast": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-            "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "*"
-            }
         },
         "@types/node": {
             "version": "20.14.9",
@@ -5959,12 +5521,6 @@
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
             "dev": true
         },
-        "ccount": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-            "dev": true
-        },
         "chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5974,18 +5530,6 @@
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
             }
-        },
-        "character-entities-html4": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-            "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-            "dev": true
-        },
-        "character-entities-legacy": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-            "dev": true
         },
         "check-more-types": {
             "version": "2.24.0",
@@ -6080,12 +5624,6 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
-        },
-        "comma-separated-tokens": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-            "dev": true
         },
         "commander": {
             "version": "6.2.1",
@@ -6244,21 +5782,6 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true
-        },
-        "dequal": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-            "dev": true
-        },
-        "devlop": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-            "dev": true,
-            "requires": {
-                "dequal": "^2.0.0"
-            }
         },
         "dir-glob": {
             "version": "3.0.1",
@@ -7063,44 +6586,10 @@
                 "function-bind": "^1.1.2"
             }
         },
-        "hast-util-to-html": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
-            "integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
-            "dev": true,
-            "requires": {
-                "@types/hast": "^3.0.0",
-                "@types/unist": "^3.0.0",
-                "ccount": "^2.0.0",
-                "comma-separated-tokens": "^2.0.0",
-                "hast-util-whitespace": "^3.0.0",
-                "html-void-elements": "^3.0.0",
-                "mdast-util-to-hast": "^13.0.0",
-                "property-information": "^6.0.0",
-                "space-separated-tokens": "^2.0.0",
-                "stringify-entities": "^4.0.0",
-                "zwitch": "^2.0.4"
-            }
-        },
-        "hast-util-whitespace": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-            "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-            "dev": true,
-            "requires": {
-                "@types/hast": "^3.0.0"
-            }
-        },
         "hosted-git-info": {
             "version": "2.8.9",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-            "dev": true
-        },
-        "html-void-elements": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-            "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
             "dev": true
         },
         "http-signature": {
@@ -7523,23 +7012,6 @@
                 "uc.micro": "^2.1.0"
             }
         },
-        "mdast-util-to-hast": {
-            "version": "13.2.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-            "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
-            "dev": true,
-            "requires": {
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "@ungap/structured-clone": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-util-sanitize-uri": "^2.0.0",
-                "trim-lines": "^3.0.0",
-                "unist-util-position": "^5.0.0",
-                "unist-util-visit": "^5.0.0",
-                "vfile": "^6.0.0"
-            }
-        },
         "mdurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -7556,45 +7028,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true
-        },
-        "micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
-            "dev": true,
-            "requires": {
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "micromark-util-encode": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
-            "dev": true
-        },
-        "micromark-util-sanitize-uri": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
-            "dev": true,
-            "requires": {
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-encode": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0"
-            }
-        },
-        "micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
-            "dev": true
-        },
-        "micromark-util-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
-            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
             "dev": true
         },
         "micromatch": {
@@ -7724,15 +7157,6 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^2.1.0"
-            }
-        },
-        "oniguruma-to-js": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
-            "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
-            "dev": true,
-            "requires": {
-                "regex": "^4.3.2"
             }
         },
         "optionator": {
@@ -7925,12 +7349,6 @@
             "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
             "dev": true
         },
-        "property-information": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
-            "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
-            "dev": true
-        },
         "proxy-from-env": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -8024,12 +7442,6 @@
                     "dev": true
                 }
             }
-        },
-        "regex": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.2.tgz",
-            "integrity": "sha512-kK/AA3A9K6q2js89+VMymcboLOlF5lZRCYJv3gzszXFHBr6kO6qLGzbm+UIugBEV8SMMKCTR59txoY6ctRHYVw==",
-            "dev": true
         },
         "regexp-tree": {
             "version": "0.1.27",
@@ -8191,20 +7603,6 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
-        "shiki": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.18.0.tgz",
-            "integrity": "sha512-8jo7tOXr96h9PBQmOHVrltnETn1honZZY76YA79MHheGQg55jBvbm9dtU+MI5pjC5NJCFuA6rvVTLVeSW5cE4A==",
-            "dev": true,
-            "requires": {
-                "@shikijs/core": "1.18.0",
-                "@shikijs/engine-javascript": "1.18.0",
-                "@shikijs/engine-oniguruma": "1.18.0",
-                "@shikijs/types": "1.18.0",
-                "@shikijs/vscode-textmate": "^9.2.2",
-                "@types/hast": "^3.0.4"
-            }
-        },
         "side-channel": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -8245,12 +7643,6 @@
                 "astral-regex": "^2.0.0",
                 "is-fullwidth-code-point": "^3.0.0"
             }
-        },
-        "space-separated-tokens": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-            "dev": true
         },
         "spdx-correct": {
             "version": "3.1.1",
@@ -8321,16 +7713,6 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
-            }
-        },
-        "stringify-entities": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-            "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-            "dev": true,
-            "requires": {
-                "character-entities-html4": "^2.0.0",
-                "character-entities-legacy": "^3.0.0"
             }
         },
         "strip-ansi": {
@@ -8450,12 +7832,6 @@
                 }
             }
         },
-        "trim-lines": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-            "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-            "dev": true
-        },
         "ts-api-utils": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -8500,16 +7876,16 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.26.7",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.7.tgz",
-            "integrity": "sha512-gUeI/Wk99vjXXMi8kanwzyhmeFEGv1LTdTQsiyIsmSYsBebvFxhbcyAx7Zjo4cMbpLGxM4Uz3jVIjksu/I2v6Q==",
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.0.tgz",
+            "integrity": "sha512-7AkTJhFdhsihthaBFHNpj5iFdLyR7FpQqXM+IABJmE1/qTjWypirCLrheToUP3fjpWHN1Drn3K7PWH1t37KvNQ==",
             "dev": true,
             "requires": {
+                "@gerrit0/mini-shiki": "^1.23.2",
                 "lunr": "^2.3.9",
                 "markdown-it": "^14.1.0",
                 "minimatch": "^9.0.5",
-                "shiki": "^1.16.2",
-                "yaml": "^2.5.1"
+                "yaml": "^2.6.1"
             },
             "dependencies": {
                 "brace-expansion": {
@@ -8549,54 +7925,6 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
-        },
-        "unist-util-is": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-            "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^3.0.0"
-            }
-        },
-        "unist-util-position": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-            "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^3.0.0"
-            }
-        },
-        "unist-util-stringify-position": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^3.0.0"
-            }
-        },
-        "unist-util-visit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-            "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^3.0.0",
-                "unist-util-is": "^6.0.0",
-                "unist-util-visit-parents": "^6.0.0"
-            }
-        },
-        "unist-util-visit-parents": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-            "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^3.0.0",
-                "unist-util-is": "^6.0.0"
-            }
         },
         "universalify": {
             "version": "2.0.0",
@@ -8666,26 +7994,6 @@
                 "extsprintf": "^1.2.0"
             }
         },
-        "vfile": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-            "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^3.0.0",
-                "vfile-message": "^4.0.0"
-            }
-        },
-        "vfile-message": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-            "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^3.0.0",
-                "unist-util-stringify-position": "^4.0.0"
-            }
-        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8724,9 +8032,9 @@
             "dev": true
         },
         "yaml": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+            "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
             "dev": true
         },
         "yauzl": {
@@ -8743,12 +8051,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true
-        },
-        "zwitch": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "typedoc-plugin-merge-modules",
     "version": "6.0.3",
+    "type": "module",
     "description": "Plugin for TypeDoc that merges the content of modules.",
     "author": {
         "name": "Krisztián Balla",
@@ -22,11 +23,11 @@
         "eslint-plugin-unicorn": "54.0.0",
         "prettier": "3.3.3",
         "rimraf": "6.0.1",
-        "typedoc": "0.26.7",
+        "typedoc": "0.27.0",
         "typescript": "5.5.4"
     },
     "peerDependencies": {
-        "typedoc": "0.26.x"
+        "typedoc": "0.27.x"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "typescript": "5.5.4"
     },
     "peerDependencies": {
-        "typedoc": "0.27.x"
+        "typedoc": "0.26.x || 0.27.x"
     },
     "repository": {
         "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { Application } from "typedoc";
-import { Plugin } from "./plugin";
-import { PluginConfig } from "./plugin_options";
+import type { Application } from "typedoc";
+import { Plugin } from "./plugin.js";
+import type { PluginConfig } from "./plugin_options.js";
 
 /**
  * Type that can be intersected with TypeDoc's config type to have static type checking for the plugin's configuration.

--- a/src/merger/module_bundle.ts
+++ b/src/merger/module_bundle.ts
@@ -1,10 +1,10 @@
-import { Comment, DeclarationReflection, DocumentReflection, ProjectReflection, ReflectionKind } from "typedoc";
+import { Comment, DeclarationReflection, DocumentReflection, type ProjectReflection, ReflectionKind } from "typedoc";
 import {
     getNameFromDescriptionTag,
     moveDeclarationReflectionToTarget,
     moveDocumentReflectionToTarget,
     removeTagFromCommentsOf,
-} from "../utils";
+} from "../utils.js";
 
 /**
  * Name of the comment tag that can be used to mark a module as the target module within the bundle.

--- a/src/merger/module_category_merger.ts
+++ b/src/merger/module_category_merger.ts
@@ -1,5 +1,5 @@
-import { DeclarationReflection } from "typedoc";
-import { ModuleMerger } from "./module_merger";
+import type { DeclarationReflection } from "typedoc";
+import { ModuleMerger } from "./module_merger.js";
 
 /**
  * Merger that merges the content of modules based on their JSDoc module annotation and category.

--- a/src/merger/module_merger.ts
+++ b/src/merger/module_merger.ts
@@ -1,7 +1,7 @@
-import { Plugin } from "src/plugin";
-import { DeclarationReflection, ProjectReflection } from "typedoc";
-import { getModulesFrom } from "../utils";
-import { ModuleBundle } from "./module_bundle";
+import type { Plugin } from "src/plugin.js";
+import type { DeclarationReflection, ProjectReflection } from "typedoc";
+import { getModulesFrom } from "../utils.js";
+import { ModuleBundle } from "./module_bundle.js";
 
 /**
  * Merger that merges the content of modules based on their JSDoc module annotation.

--- a/src/merger/project_merger.ts
+++ b/src/merger/project_merger.ts
@@ -1,7 +1,7 @@
-import { ProjectReflection } from "typedoc";
-import { Plugin } from "../plugin";
-import { getModulesFrom } from "../utils";
-import { ModuleBundle } from "./module_bundle";
+import type { ProjectReflection } from "typedoc";
+import type { Plugin } from "../plugin.js";
+import { getModulesFrom } from "../utils.js";
+import { ModuleBundle } from "./module_bundle.js";
 
 /**
  * Merger that moves the content of all modules into the project root.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,17 +1,17 @@
 import {
     Application,
-    Context,
+    type Context,
     Converter,
-    DeclarationReflection,
+    type DeclarationReflection,
     EntryPointStrategy,
-    ProjectReflection,
+    type ProjectReflection,
     ReflectionKind,
 } from "typedoc";
-import { ModuleCategoryMerger } from "./merger/module_category_merger";
-import { ModuleMerger } from "./merger/module_merger";
-import { ProjectMerger } from "./merger/project_merger";
-import { PluginOptions } from "./plugin_options";
-import { tryGetOriginalReflectionName } from "./utils";
+import { ModuleCategoryMerger } from "./merger/module_category_merger.js";
+import { ModuleMerger } from "./merger/module_merger.js";
+import { ProjectMerger } from "./merger/project_merger.js";
+import { PluginOptions } from "./plugin_options.js";
+import { tryGetOriginalReflectionName } from "./utils.js";
 
 /**
  * The "Merge Modules" plugin.

--- a/src/plugin_options.ts
+++ b/src/plugin_options.ts
@@ -1,4 +1,4 @@
-import { Application, ParameterType } from "typedoc";
+import { type Application, ParameterType } from "typedoc";
 
 /** Type for the plugin's mode. */
 type Mode = "project" | "module" | "module-category" | "off";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,12 @@
 import {
-    CommentTag,
-    Context,
+    type CommentTag,
+    type Context,
     DeclarationReflection,
-    DocumentReflection,
-    ProjectReflection,
+    type DocumentReflection,
+    type ProjectReflection,
     ReflectionKind,
 } from "typedoc";
-import * as ts from "typescript";
+import type * as ts from "typescript";
 
 /**
  * Type extending the TypeScript Declaration interface with a possible identifier object as a name.

--- a/test/cypress.config.js
+++ b/test/cypress.config.js
@@ -1,7 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/unbound-method
-const { defineConfig } = require("cypress");
+import { defineConfig } from "cypress";
 
-module.exports = defineConfig({
+const config = defineConfig({
     e2e: {
         specPattern: "**/*.cy.ts",
         supportFile: false,
@@ -9,3 +8,5 @@ module.exports = defineConfig({
         screenshotOnRunFailure: false,
     },
 });
+
+export default config;

--- a/test/merge-module-category/test.cy.ts
+++ b/test/merge-module-category/test.cy.ts
@@ -46,7 +46,7 @@ describe("modules/merged-1.html", () => {
     });
 
     it("contains a sub link to the class C", () => {
-        cy.get("nav").find("a[href='../classes/merged-1.C.html']");
+        cy.get("nav").find("a[href='../classes/merged.C.html']");
     });
 });
 
@@ -56,6 +56,6 @@ describe("modules/merged-2.html", () => {
     });
 
     it("contains a sub link to the class D", () => {
-        cy.get("nav").find("a[href='../classes/merged-2.D.html']");
+        cy.get("nav").find("a[href='../classes/merged.D.html']");
     });
 });

--- a/test/merge-module-monorepo/test.cy.ts
+++ b/test/merge-module-monorepo/test.cy.ts
@@ -43,29 +43,29 @@ describe("modules/Project_2.merged.html", () => {
     });
 
     it("contains index links to the classes A, B and C", () => {
-        cy.get(".col-content .tsd-index-list").find("a[href='../classes/Project_2.merged.A.html']");
-        cy.get(".col-content .tsd-index-list").find("a[href='../classes/Project_2.merged.B.html']");
-        cy.get(".col-content .tsd-index-list").find("a[href='../classes/Project_2.merged.C.html']");
+        cy.get(".col-content .tsd-member-summaries").find("a[href='../classes/Project_2.merged.A.html']");
+        cy.get(".col-content .tsd-member-summaries").find("a[href='../classes/Project_2.merged.B.html']");
+        cy.get(".col-content .tsd-member-summaries").find("a[href='../classes/Project_2.merged.C.html']");
     });
 
     it("contains the category Alpha and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(2)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(2)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Alpha");
+        cy.get(sectionSelector + " h2").should("have.text", " Alpha");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of A.");
     });
 
     it("contains the category Beta and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(3)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(3)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Beta");
+        cy.get(sectionSelector + " h2").should("have.text", " Beta");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of B.");
     });
 
     it("contains the category Gamma and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(1)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(1)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Gamma");
+        cy.get(sectionSelector + " h2").should("have.text", " Gamma");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of C.");
     });
 });

--- a/test/merge-module/test.cy.ts
+++ b/test/merge-module/test.cy.ts
@@ -32,9 +32,9 @@ describe("modules/notMerged.html", () => {
     });
 
     it("contains the category Gamma and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(1)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(1)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Gamma");
+        cy.get(sectionSelector + " h2").should("have.text", " Gamma");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of C.");
     });
 });
@@ -50,16 +50,16 @@ describe("modules/merged.html", () => {
     });
 
     it("contains the category Alpha and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(1)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(1)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Alpha");
+        cy.get(sectionSelector + " h2").should("have.text", " Alpha");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of A.");
     });
 
     it("contains the category Beta and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(2)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(2)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Beta");
+        cy.get(sectionSelector + " h2").should("have.text", " Beta");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of B.");
     });
 });

--- a/test/merge-project-monorepo/test.cy.ts
+++ b/test/merge-project-monorepo/test.cy.ts
@@ -28,23 +28,23 @@ describe("modules.html", () => {
     });
 
     it("contains the category Alpha and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(1)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(1)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Alpha");
+        cy.get(sectionSelector + " h2").should("have.text", " Alpha");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of A.");
     });
 
     it("contains the category Beta and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(2)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(2)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Beta");
+        cy.get(sectionSelector + " h2").should("have.text", " Beta");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of B.");
     });
 
     it("contains the category Gamma and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(3)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(3)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Gamma");
+        cy.get(sectionSelector + " h2").should("have.text", " Gamma");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of C.");
     });
 });

--- a/test/merge-project/test.cy.ts
+++ b/test/merge-project/test.cy.ts
@@ -27,23 +27,23 @@ describe("modules.html", () => {
     });
 
     it("contains the category Alpha and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(1)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(1)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Alpha");
+        cy.get(sectionSelector + " h2").should("have.text", " Alpha");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of A.");
     });
 
     it("contains the category Beta and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(2)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(2)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Beta");
+        cy.get(sectionSelector + " h2").should("have.text", " Beta");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of B.");
     });
 
     it("contains the category Gamma and its description", () => {
-        const sectionSelector = ".col-content .tsd-index-section:nth-of-type(3)";
+        const sectionSelector = ".col-content .tsd-panel-group:nth-of-type(3)";
 
-        cy.get(sectionSelector + " h3").should("have.text", "Gamma");
+        cy.get(sectionSelector + " h2").should("have.text", " Gamma");
         cy.get(sectionSelector + " p").should("have.text", "Category description from the file of C.");
     });
 });

--- a/test/prepare_test.js
+++ b/test/prepare_test.js
@@ -1,10 +1,14 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const fs = require("fs");
-const path = require("path");
+import fs from "node:fs/promises";
+import path from "node:path";
 
 console.log("=================================== SETTING UP THE TESTS ===========================================");
 
-if (!fs.existsSync(path.join("..", "dist"))) {
+if (
+    !(await fs
+        .access(path.join("..", "dist"))
+        .then(() => true)
+        .catch(() => false))
+) {
     console.error("ERROR: Cannot find 'dist' folder. Did you forget to build the plugin with 'npm run build'?");
     process.exit(1);
 }
@@ -12,18 +16,9 @@ if (!fs.existsSync(path.join("..", "dist"))) {
 console.log("Copying current build of plugin to node_modules for testing...");
 const nodeModulesSubDir = path.join("..", "node_modules", "typedoc-plugin-merge-modules");
 
-fs.rm(nodeModulesSubDir, { recursive: true, force: true }, (rmErr) => {
-    if (rmErr) {
-        throw rmErr;
-    }
-    fs.mkdir(path.join(nodeModulesSubDir, "dist"), { recursive: true }, (mkDirErr) => {
-        if (mkDirErr) {
-            throw mkDirErr;
-        } else {
-            fs.copyFileSync(path.join("..", "package.json"), path.join(nodeModulesSubDir, "package.json"));
-            fs.cpSync(path.join("..", "dist"), path.join(nodeModulesSubDir, "dist"), { recursive: true });
-        }
-    });
-});
+await fs.rm(nodeModulesSubDir, { recursive: true, force: true });
+await fs.mkdir(path.join(nodeModulesSubDir, "dist"), { recursive: true });
+await fs.copyFile(path.join("..", "package.json"), path.join(nodeModulesSubDir, "package.json"));
+await fs.cp(path.join("..", "dist"), path.join(nodeModulesSubDir, "dist"), { recursive: true });
 
 console.log("DONE\n");

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { execSync } = require("child_process");
+import { execSync } from "node:child_process";
 const execOptions = { stdio: "inherit" };
 
 console.log("===================================== TEST MERGE OFF ===============================================");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,14 @@
     "compilerOptions": {
         "outDir": "dist",
         "target": "es2015",
-        "module": "commonjs",
+        "module": "node16",
         "declaration": true,
         "baseUrl": "./",
         "strict": true,
         "noImplicitOverride": true,
         "exactOptionalPropertyTypes": true,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "verbatimModuleSyntax": true
     }
 }


### PR DESCRIPTION
Since 0.27, TypeDoc now uses ESM. Plugins that still use CommonJS won't work, since they often import from `typedoc`, but CommonJS can't import ESM.

* https://github.com/TypeStrong/typedoc/blob/master/CHANGELOG.md#breaking-changes
* https://github.com/TypeStrong/typedoc/issues/2763#issuecomment-2496064319


After the update to TypeDoc 0.27.0, there are some test failures related to `@categoryDescription` that I haven't figured out yet. Not sure if it's a problem with typedoc or the plugin, but [this plugin seems to have some code for that tag](https://github.com/krisztianb/typedoc-plugin-merge-modules/blob/120293a87ab20f4eef4b1dfec8f93c50338c346d/src/merger/module_bundle.ts#L169) and the [TypeDoc's changelog for 0.27.0 also contains a change for that tag](https://github.com/TypeStrong/typedoc/blob/master/CHANGELOG.md#breaking-changes).


```
[error] The plugin typedoc-plugin-merge-modules could not be loaded
[error] Error [ERR_REQUIRE_ESM]: require() of ES Module /home/user/user/node_modules/typedoc/dist/index.js from /home/user/demo/node_modules/typedoc-plugin-merge-modules/dist/plugin.js not supported.
Instead change the require of index.js in /home/user/demo/node_modules/typedoc-plugin-merge-modules/dist/plugin.js to a dynamic import() which is available in all CommonJS modules.
```